### PR TITLE
Allow subclassing for InsensitiveHash

### DIFF
--- a/lib/insensitive_hash/insensitive_hash.rb
+++ b/lib/insensitive_hash/insensitive_hash.rb
@@ -69,7 +69,7 @@ class InsensitiveHash < Hash
   # @see http://www.ruby-doc.org/core-1.9.3/Hash.html Hash
   def self.[] *init
     h = Hash[*init]
-    InsensitiveHash.new.tap do |ih|
+    self.new.tap do |ih|
       ih.merge_recursive! h
     end
   end
@@ -103,7 +103,7 @@ class InsensitiveHash < Hash
 
   # @see http://www.ruby-doc.org/core-1.9.3/Hash.html Hash
   def merge other_hash
-    InsensitiveHash.new.tap do |ih|
+    self.class.new.tap do |ih|
       ih.replace self
       ih.merge! other_hash
     end
@@ -187,13 +187,13 @@ private
 
   def wrap value
     case value
-    when InsensitiveHash
+    when InsensitiveHash, self.class
       value.tap { |ih|
         ih.safe = safe?
         ih.encoder = encoder
       }
     when Hash
-      InsensitiveHash.new.tap { |ih|
+      self.class.new.tap { |ih|
         ih.safe = safe?
         ih.encoder = encoder
         ih.merge_recursive!(value)

--- a/test/test_insensitive_hash.rb
+++ b/test/test_insensitive_hash.rb
@@ -621,5 +621,13 @@ class TestInsensitiveHash < Test::Unit::TestCase
       assert_equal :d, ih[:any][:any][:any]
     end
   end
-end
 
+  class MyInsensitiveHash < InsensitiveHash
+  end
+
+  def test_subclassing
+    mih = MyInsensitiveHash[{ "a" => { "b" => 3 } }]
+    assert_instance_of MyInsensitiveHash, mih
+    assert_instance_of MyInsensitiveHash, mih["a"]
+  end
+end


### PR DESCRIPTION
Currently there wasn't any way to subclass  `InsensitiveHash`.

``` ruby
class MyInsensitiveHash < InsensitiveHash
  def test
  end
end 
hash = MyInsensitiveHash[{}]
hash.class
=> InsensitiveHash
hash.test
NoMethodError: private method `test' called for {}:InsensitiveHash
```

this PR fixes it so can easily subclass :)
